### PR TITLE
bump verion to 1.0.6

### DIFF
--- a/rudder_analytics/version.py
+++ b/rudder_analytics/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.5'
+VERSION = '1.0.6'


### PR DESCRIPTION
Bump `rudder-sdk-python` version to `1.0.6`, reflecting changes in: #1 